### PR TITLE
Add Docker build instructions for Ubuntu

### DIFF
--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -1,0 +1,30 @@
+FROM ubuntu:22.04 AS builder
+
+RUN apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y \
+        build-essential git bison cmake \
+        libmysqlclient-dev libpcre3-dev libpq-dev \
+        libsqlite3-dev libssl-dev libz-dev \
+        libjemalloc-dev libicu-dev
+
+WORKDIR /build
+
+COPY . /build/fluffos
+
+RUN mkdir build && cd build && \
+    cmake .. && \
+    make -j$(nproc) install
+
+FROM ubuntu:22.04
+
+RUN apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y \
+        libjemalloc2 libicu70 libssl3 libpcre3 \
+        libmysqlclient-dev libpq5 libsqlite3-0 zlib1g && \
+    rm -rf /var/lib/apt/lists/*
+
+WORKDIR /fluffos
+
+COPY --from=builder /build/fluffos/build/bin ./bin
+
+ENTRYPOINT ["/fluffos/bin/driver"]

--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ Support
 How to Build
 ------------
 see <https://www.fluffos.info/build.html>
+For building with Docker on Ubuntu see [docs/docker-ubuntu.md](docs/docker-ubuntu.md)
 
 Bundled Third-party Dependencies
 ----------------------

--- a/docs/build.md
+++ b/docs/build.md
@@ -190,3 +190,18 @@ Check the result file to make sure it is a static file.
 $ ldd bin/driver
     not a dynamic executable
 ```
+
+## Docker (Ubuntu 22.04+)
+
+FluffOS can also be built inside a Docker container based on Ubuntu 22.04. A
+sample Dockerfile is provided in [docs/docker-ubuntu.md](docker-ubuntu.md).
+To build the image and run the driver:
+
+```bash
+docker build -t fluffos:ubuntu -f Dockerfile.ubuntu .
+
+docker run -it --rm fluffos:ubuntu
+```
+
+You may mount your mudlib directory to the container when starting it.
+

--- a/docs/docker-ubuntu.md
+++ b/docs/docker-ubuntu.md
@@ -1,0 +1,68 @@
+---
+layout: doc
+title: Docker (Ubuntu 22.04+)
+---
+
+# Building FluffOS using Docker on Ubuntu 22.04+
+
+This page shows how to build and install FluffOS inside a Docker container
+based on Ubuntu 22.04. The produced image contains the `driver` binary
+ready to run.
+
+## Dockerfile
+
+Create a file named `Dockerfile.ubuntu` with the following content:
+
+```Dockerfile
+FROM ubuntu:22.04 AS builder
+
+RUN apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y \
+        build-essential git bison cmake \
+        libmysqlclient-dev libpcre3-dev libpq-dev \
+        libsqlite3-dev libssl-dev libz-dev \
+        libjemalloc-dev libicu-dev
+
+WORKDIR /build
+
+COPY . /build/fluffos
+
+RUN mkdir build && cd build && \
+    cmake .. && \
+    make -j$(nproc) install
+
+FROM ubuntu:22.04
+
+RUN apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y \
+        libjemalloc2 libicu70 libssl3 libpcre3 \
+        libmysqlclient-dev libpq5 libsqlite3-0 zlib1g && \
+    rm -rf /var/lib/apt/lists/*
+
+WORKDIR /fluffos
+
+COPY --from=builder /build/fluffos/build/bin ./bin
+
+ENTRYPOINT ["/fluffos/bin/driver"]
+```
+
+## Build the image
+
+```bash
+docker build -t fluffos:ubuntu -f Dockerfile.ubuntu .
+```
+
+## Run FluffOS
+
+```bash
+docker run -it --rm fluffos:ubuntu
+```
+
+You can mount your own mudlib when starting the container:
+
+```bash
+docker run -it --rm -v /path/to/mudlib:/mudlib fluffos:ubuntu \
+  /fluffos/bin/driver /mudlib
+```
+
+Prebuilt images are also available from [Docker Hub](https://hub.docker.com/r/fluffos/fluffos).


### PR DESCRIPTION
## Summary
- document how to build FluffOS on Docker with Ubuntu 22.04+
- reference the new instructions from README and build docs
- provide a sample Dockerfile for Ubuntu

## Testing
- `cmake --version`


------
https://chatgpt.com/codex/tasks/task_e_686f87cad2348325bf0762e3a370788b