### PR TITLE
Fix Docker build directory issue

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+/build
+/build*
+/cmake-build-*
+.git

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN ./configure --prefix=/usr \
     && make install
 
 COPY . /build/fluffos
-RUN mkdir /build/fluffos/build
+RUN mkdir -p /build/fluffos/build
 
 WORKDIR /build/fluffos/build
 RUN cmake .. -DMARCH_NATIVE=OFF -DSTATIC=ON \


### PR DESCRIPTION
## Summary
- add .dockerignore to avoid copying local build artifacts
- make Dockerfile's build directory creation resilient

## Testing
- `docker --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686fa03ddcac8325933145d41b90bcbf