### PR TITLE
Fix Docker instructions

### DIFF
--- a/docs/build.md
+++ b/docs/build.md
@@ -203,5 +203,11 @@ docker build -t fluffos:ubuntu -f Dockerfile.ubuntu .
 docker run -it --rm fluffos:ubuntu
 ```
 
-You may mount your mudlib directory to the container when starting it.
+You may mount your mudlib directory to the container when starting it. Specify
+the configuration file inside your mudlib when launching the driver:
+
+```bash
+docker run -it --rm -v /path/to/mudlib:/mudlib fluffos:ubuntu \
+  /fluffos/bin/driver /mudlib/etc/config.test
+```
 

--- a/docs/docker-ubuntu.md
+++ b/docs/docker-ubuntu.md
@@ -64,7 +64,7 @@ You can mount your own mudlib when starting the container:
 
 ```bash
 docker run -it --rm -v /path/to/mudlib:/mudlib fluffos:ubuntu \
-  /fluffos/bin/driver /mudlib
+  /fluffos/bin/driver /mudlib/etc/config.test
 ```
 
 Prebuilt images are also available from [Docker Hub](https://hub.docker.com/r/fluffos/fluffos).


### PR DESCRIPTION
## Summary
- update Docker run instructions to pass config file

## Testing
- `npm install` *(fails: vitepress not found)*
- `timeout 5 npm run --silent build` *(fails: large output)*

------
https://chatgpt.com/codex/tasks/task_e_686fb161f67083258a5200af45a7ad81